### PR TITLE
Updated azuredeploy.bicep to configure App Service to B1 SKU

### DIFF
--- a/Labs/deploy/azuredeploy.bicep
+++ b/Labs/deploy/azuredeploy.bicep
@@ -39,7 +39,7 @@ param name string = 'dg${uniqueString(resourceGroup().id)}'
   'S1'
   'P0v3'
 ])
-param appServiceSku string = 'P0v3' //'B1'
+param appServiceSku string = 'B1' //'P0v3' for production workloads
 
 @description('Specifies the SKU for the Azure OpenAI resource. Defaults to **S0**')
 @allowed([


### PR DESCRIPTION
The `appServiceSku` parameter describes itself as defaulting to 'B1' whereas the code configures the app service to a production grade SKU 'P0v3'. The SKU should default to B1 considering that this is a lab an will dominantly be used by students and professionals for learning exercises.